### PR TITLE
Operation state text

### DIFF
--- a/atd-kits/signal_status_publisher.py
+++ b/atd-kits/signal_status_publisher.py
@@ -33,6 +33,11 @@ FLASH_STATUSES = [1, 2, 3]
 SIGNAL_STATUS_RESOURCE_ID = "5zpr-dehc"
 SIGNALS_RESOURCE_ID = "p53x-x73x"
 
+STATUS_NAMES = {
+    1: "Scheduled flash",
+    2: "Unscheduled (Conflict) flash",
+    3: "Communication issue",
+}
 
 def get_kits_signal_status(server, user, password, database):
     """ Fetch traffic signal operation statuses from the KITS mssql database """
@@ -58,6 +63,14 @@ def get_kits_signal_status(server, user, password, database):
             cursor.execute(query)
             return cursor.fetchall()
 
+
+def decode_signal_status(kits_sig_status):
+    """
+    Converts KITS status codes into human-readable text.
+    """
+    for sig in kits_sig_status:
+        sig["operation_text"] = STATUS_NAMES[sig["operation_state"]]
+    return kits_sig_status
 
 def get_socrata_data(resource_id, params):
     endpoint = f"https://data.austintexas.gov/resource/{resource_id}.json"
@@ -122,6 +135,8 @@ def main():
     )
 
     logger.info(f"{len(kits_sig_status)} records to process.")
+
+    kits_sig_status = decode_signal_status(kits_sig_status)
 
     stringify_signal_ids(kits_sig_status)
 


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/12151

Adds a function and lookup dict to decode the three status codes from KITS into human-readable text.

I've edited the [Socrata dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Traffic-Signals-Status/5zpr-dehc) to add the `operation_text` column. Testing this branch locally will populate that column with data. There is an [airflow DAG](https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_kits_signal_status_pub.py) that runs every 5 minutes with the production branch, so this column will be blank until we merge this and pull the changes down on that machine.

