### PR TITLE
Update Docker CI plugin versions and support multi-platform builds

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -3,31 +3,27 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [production, staging]
-
+    branches:
+      - production
+      - staging
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      -
-        name: Build and push
+      - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ secrets.DOCKER_USERNAME }}/atd-kits:production
-            ${{ secrets.DOCKER_USERNAME }}/atd-kits:staging
-            ${{ secrets.DOCKER_USERNAME }}/atd-kits:latest
-      -
-        name: Image digest
+          # tag with `production` if production branch else staging
+          tags: ${{ secrets.DOCKER_USERNAME }}/atd-metrobike:${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }}
+      - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -21,7 +21,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           # tag with `production` if production branch else staging
           tags: ${{ secrets.DOCKER_USERNAME }}/atd-metrobike:${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM python:3.8-slim
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.8-slim
 RUN apt-get update && apt-get install -y \
     freetds-bin \
     freetds-common \
-    freetds-dev
+    freetds-dev \
+    build-essential libkrb5-dev libssl-dev
 
 # Copy our own application
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM --platform=linux/amd64 python:3.8-slim
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
In service of:
- https://github.com/cityofaustin/atd-data-tech/issues/12882

~Well, Microsoft doesn't make it easy to run their SQL server driver on Applie Silicon. I tried a few different approaches, but ultimately found that I could at least build/run this image locally by specifying the AMD platform during build.

Once the Github action builds and pushes, I'm not _positive_ M1 users will be able to pull and run it. You may have to build locally. This stuff is over my head :/~

Thank you @frankhereford for getting this working!