### PR TITLE
Fixing building complexities for the KITS image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM python:3.8-slim
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.8-slim
 RUN apt-get update && apt-get install -y \
     freetds-bin \
     freetds-common \
-    freetds-dev
+    freetds-dev \
+    build-essential libkrb5-dev libssl-dev
 
 # Copy our own application
 WORKDIR /app


### PR DESCRIPTION
@johnclary 👋 

Thank you [for working on this image](https://github.com/cityofaustin/atd-kits/pull/9). I pulled it down and tried to build it on my mac. There is something that makes building for ARM chips end up compiling a lot more of the software in the stack contained in the docker image than when it's building for AMD64. I'm not really positive why what is compiling when it does, but I was able to get it compile by adding some build utilities and some library header files. 

I didn't want to push on your branch, but if you'd like to merge this, please feel free at any time - it's all yours. Also - same goes for closing the PR too!

Thanks!!