### PR TITLE
Working build that runs on Apple chips & AMD64

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -1,4 +1,5 @@
 # Build and push docker image with production **and** staging tags
+# trigger action
 name: Docker Image CI
 
 on:

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -1,5 +1,4 @@
 # Build and push docker image with production **and** staging tags
-# trigger action
 name: Docker Image CI
 
 on:

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -21,7 +21,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           # tag with `production` if production branch else staging
           tags: ${{ secrets.DOCKER_USERNAME }}/atd-kits:${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM --platform=linux/amd64 python:3.8-slim
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \
@@ -13,6 +13,8 @@ COPY . /app/atd-kits
 
 RUN chmod -R 755 /app/*
 
+RUN pip install -U pip
+
 ## Proceed to install the requirements...do
-RUN cd /app/atd-kits && apt-get update && \
+RUN cd /app/atd-kits && \
     pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ COPY . /app/atd-kits
 
 RUN chmod -R 755 /app/*
 
-RUN pip install -U pip
-
 ## Proceed to install the requirements...do
 RUN cd /app/atd-kits && \
     pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-buster
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# just a comment
 FROM python:3.8-slim
 
 #  Required for pymssql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM --platform=linux/amd64 python:3.8-slim
+# test
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM --platform=linux/amd64 python:3.8-slim
-# test
 
 #  Required for pymssql
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# just a comment
 FROM python:3.8-slim
 
 #  Required for pymssql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow==0.*
-pymssql==2.*
-requests==2.*
-sodapy==2.*
+arrow>=0.17.*
+pymssql>=2.1.*
+requests>=2.2.*
+sodapy>=2.1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow>=0.17.*
-pymssql
-requests>=2.2.*
-sodapy>=2.1.*
+arrow>=0.*
+pymssql>=2.*
+requests>=2.*
+sodapy>=2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow>=0.*
-pymssql>=2.*
-requests>=2.*
-sodapy>=2.*
+arrow==0.*
+pymssql==2.*
+requests==2.*
+sodapy==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 arrow>=0.17.*
-pymssql>=2.1.*
+pymssql
 requests>=2.2.*
 sodapy>=2.1.*


### PR DESCRIPTION
@johnclary 👋,

## 😵‍💫 

Above all - this is the furthest thing from urgent. I have been fiddling with it while listening to a meeting. Surprisingly, I stumbled into something that works.

That said, I'm not sure why this is working, but it's working. All this does is add the ARM64 platform to the GitHub action, and interestingly, what it also does, is it /leaves/ in the `--platform=linux/amd64` that you had found in your solution. 

I have tested this by forking this repo into my own account and triggering the building there into my own dockerhub account. 

Recent GH Action run: https://github.com/frankhereford/atd-kits/actions/runs/5579274926
Output of GH build on DockerHub: https://hub.docker.com/repository/docker/frankinaustin/atd-kits/general

Interestingly, you can see that the two images on dockerhub are the exact same size, so I think what it's done is not actually compiled native ARM code, but somehow labeled the AMD64 stuff so that docker on a Mac knows to use qemu. I'm not sure about this - this is my best guess.

But it's running! It pulls and runs both on my mac and an intel linux machine. It starts bash at least; I don't have the environment setup to actually run the DAG. 

Thanks!